### PR TITLE
Surrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ require('latex').setup{
     enabled = true,
     add = {},
     default_leader = "`"
-  }
+  },
+  surrounds = {
+    enabled = false,
+    command = "c",
+    environment = "e",
+  },
 }
 ```
 
@@ -121,6 +126,18 @@ and the value should be the single-character conceal to replace that command wit
 The `add` table is for concealing `generic_command` elements.
 Unlike most other conceals, these are *not* sensitive to the presence or absence of math mode.
  
+ ### Surrounds
+
+ Requires [nvim-surround](https://github.com/kylechui/nvim-surround).
+ Actually at the moment requires the `patch-1` branch of [my fork](https://github.com/ryleelyman/nvim-surround),
+ so probably best to wait a bit.
+ Provides `add`, `change` and `delete` for commands and environments.
+ With default settings for `nvim-surround`, these are mapped to,
+ for example, `csc` for `c`hange `s`urrounding `c`ommand and
+ `dse` for `d`elete `s`urrounding `e`nvironment.
+
+ To enable, set `surrounds.enabled` to `true`.
+
  ## Non-features
  
  - compilation, forward/backward search, completion, linting—use [texlab](https://github.com/latex-lsp/texlab)

--- a/lua/latex.lua
+++ b/lua/latex.lua
@@ -2,6 +2,7 @@ local L = {}
 
 L.imaps = require('latex.module.imaps')
 L.conceals = require('latex.module.conceals')
+L.surrounds = require('latex.module.surrounds')
 
 L.__index = L
 
@@ -20,6 +21,11 @@ L._defaults = {
     enabled = true,
     add = {},
     default_leader = "`"
+  },
+  surrounds = {
+    enabled = false,
+    command = "c",
+    environment = "e"
   }
 }
 
@@ -30,12 +36,14 @@ function L.setup(args)
     pattern = {"*.tex"},
     callback = function()
       L.imaps.init(args.imaps, "tex")
+      L.surrounds.init(args.surrounds)
     end
   })
   vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
     pattern = {"*.md"},
     callback = function()
       L.imaps.init(args.imaps, "markdown")
+      L.surrounds.init(args.surrounds)
     end
   })
   vim.api.nvim_create_autocmd({"BufLeave", "BufWinLeave"}, {

--- a/lua/latex/module/surrounds.lua
+++ b/lua/latex/module/surrounds.lua
@@ -11,10 +11,7 @@ function M.init(config)
         end,
         find = function()
           return require("nvim-surround.config").get_selection{
-            query = {
-              capture = "@function",
-              type = "highlights",
-            }
+            node = {"generic_command", "label_definition"}
           }
         end,
         change = {
@@ -23,7 +20,18 @@ function M.init(config)
             local cmd = require("nvim-surround.config").get_input "Command: "
             return { { cmd } , { } }
           end
-        }
+        },
+        delete = function ()
+          local sel = require("nvim-surround.config").get_selections{
+            char = config.command,
+            pattern = "^(\\.-{)().-(})()$"
+          }
+          if sel then return sel end
+          return require("nvim-surround.config").get_selections{
+            char = config.command,
+            pattern = "^(\\.*)().-()()$"
+          }
+        end
       },
       [config.environment] = {
         add = function()
@@ -35,7 +43,17 @@ function M.init(config)
             node = {"generic_environment", "math_environment"}
           }
         end,
-        delete = "^(\\begin{[^%}]*}%[[^%]]*%])().-(\\end{[^%}]*})()$",
+        delete = function()
+          local sel = require("nvim-surround.config").get_selections{
+            char = config.environment,
+            pattern = "^(\\begin%b{}%b[])().-(\\end%b{})()$"
+          }
+          if sel then return sel end
+          return require("nvim-surround.config").get_selections{
+            char = config.environment,
+            pattern = "^(\\begin%b{})().-(\\end%b{})()$"
+          }
+        end,
         change = {
           target = "^\\begin{([^%}]*)().-\\end{([^%}]*)()}$",
           replacement = function ()

--- a/lua/latex/module/surrounds.lua
+++ b/lua/latex/module/surrounds.lua
@@ -1,0 +1,51 @@
+local M = {}
+
+function M.init(config)
+  if not config.enabled then return end
+  require("nvim-surround").buffer_setup {
+    surrounds = {
+      [config.command] = {
+        add = function()
+          local cmd = require("nvim-surround.config").get_input "Command: "
+          return { { "\\" .. cmd .. "{" }, { "}" } }
+        end,
+        find = function()
+          return require("nvim-surround.config").get_selection{
+            query = {
+              capture = "@function",
+              type = "highlights",
+            }
+          }
+        end,
+        change = {
+          target = "^\\([^%{]*)().-()()$",
+          replacement = function ()
+            local cmd = require("nvim-surround.config").get_input "Command: "
+            return { { cmd } , { } }
+          end
+        }
+      },
+      [config.environment] = {
+        add = function()
+          local env = require("nvim-surround.config").get_input "Environment: "
+          return { { "\\begin{" .. env .. "}" }, { "\\end{" .. env .. "}" } }
+        end,
+        find = function ()
+          return require("nvim-surround.config").get_selection{
+            node = {"generic_environment", "math_environment"}
+          }
+        end,
+        delete = "^(\\begin{[^%}]*}%[[^%]]*%])().-(\\end{[^%}]*})()$",
+        change = {
+          target = "^\\begin{([^%}]*)().-\\end{([^%}]*)()}$",
+          replacement = function ()
+            local cmd = require("nvim-surround.config").get_input "Environment: "
+            return { { cmd }, { cmd } }
+          end
+        }
+      },
+    },
+  }
+end
+
+return M


### PR DESCRIPTION
Adds integration with `nvim-surround`, which is disabled by default. Currently requires the `patch-1` branch of [my fork](https://github.com/ryleelyman/nvim-surround), so probably best to wait a bit before using.