### PR TITLE
bug: update treesitter query API parameter format

### DIFF
--- a/lua/latex/module/conceals.lua
+++ b/lua/latex/module/conceals.lua
@@ -52,8 +52,8 @@ end
 
 local function load_queries(args)
   local filenames = vim.treesitter.query.get_files('latex', 'highlights')
-  vim.treesitter.query.add_predicate('has-grandparent?', hasgrandparent, true)
-  vim.treesitter.query.add_directive('set-pairs!', setpairs, true)
+  vim.treesitter.query.add_predicate('has-grandparent?', hasgrandparent, {force = true})
+  vim.treesitter.query.add_directive('set-pairs!', setpairs, {force = true})
   for _, name in ipairs(args.enabled) do
     local files = vim.api.nvim_get_runtime_file("queries/latex/conceal_" .. name .. ".scm", true)
     for _, file in ipairs(files) do


### PR DESCRIPTION
Update the parameter format for `vim.treesitter.query.add_predicate` and 
vim.treesitter.query.add_directive to use the new table format `{force = true}`
instead of the deprecated boolean parameter.

This change addresses API updates in Neovim's treesitter interface while 
maintaining the same functionality.